### PR TITLE
Detect working directory for flake8's config

### DIFF
--- a/Scripts/Flake8Process.js
+++ b/Scripts/Flake8Process.js
@@ -18,6 +18,7 @@ class Flake8Process {
             flake8Path,
             {
                 args: commandArguments,
+                cwd: nova.workspace.path,
                 shell: true,
                 stdio: ["ignore", "pipe", "pipe"]
             }


### PR DESCRIPTION
Hi, thanks for this extension!

By default, Nova's Process appears to have an `undefined` working directory:

```
const process = Process.new(...)
console.log(process.cwd) # undefined
```

Since flake8 looks for a config in either your home directory or your project (read: current) directory, if the current directory is undefined it can't find the project's config.

This commit sets the directory for Process to [nova's workspace path] which allows flake8 to find the config. Nova also added a trailing newline.

[nova's workspace path]: https://docs.nova.app/api-reference/workspace/#path