### PR TITLE
Refactor for asynchronous saving

### DIFF
--- a/Scripts/BlackProcess.js
+++ b/Scripts/BlackProcess.js
@@ -1,4 +1,5 @@
 class BlackProcess {
+
     constructor() {
         this.stdOutOutput = "";
         this.stdErrorOutput = "";
@@ -11,11 +12,14 @@ class BlackProcess {
             blackPath = "/usr/bin/env";
             commandArguments = ["black", ...commandArguments];
         }
-        return new Process(blackPath, {
-            args: commandArguments,
-            shell: true,
-            stdio: "pipe",
-        });
+        return new Process(
+            blackPath,
+            {
+                args: commandArguments,
+                shell: true,
+                stdio: "pipe"
+            }
+        );
     }
 
     execute(content) {

--- a/Scripts/Formatter.js
+++ b/Scripts/Formatter.js
@@ -1,6 +1,7 @@
 const BlackProcess = require("./BlackProcess");
 
 class Formatter {
+
     constructor() {
         this.process = new BlackProcess();
     }

--- a/Scripts/Formatter.js
+++ b/Scripts/Formatter.js
@@ -1,9 +1,22 @@
 const BlackProcess = require("./BlackProcess");
 
 class Formatter {
-
     constructor() {
         this.process = new BlackProcess();
+    }
+
+    notifyError(message) {
+        let request = new NotificationRequest("blake-black-error");
+        request.title = nova.localize("Black error");
+        request.body = nova.localize(message);
+        request.actions = [nova.localize("OK")];
+        let promise = nova.notifications.add(request);
+        promise.then(
+            (reply) => {},
+            (error) => {
+                console.error(error);
+            }
+        );
     }
 
     format(editor) {
@@ -11,15 +24,20 @@ class Formatter {
 
         const textRange = new Range(0, editor.document.length);
         const content = editor.document.getTextInRange(textRange);
-        this.process.onComplete((formattedContent) => {
-            // If Black isn't installed, the existing code will be formatted as
-            // a single space. If that's the case, we skip that step.
-            if (formattedContent == content || formattedContent.trim() === "") return;
-            editor.edit((edit) => {
-               edit.replace(textRange, formattedContent);
-            });
-        });
-        this.process.execute(content);
+        return this.process
+            .execute(content)
+            .then((formattedContent) => {
+                // If Black isn't installed, the existing code will be formatted as
+                // a single space. If that's the case, we skip that step.
+                const isChangedContent = formattedContent != content;
+                const isNonEmptyContent = formattedContent.trim() !== "";
+                if (isChangedContent && isNonEmptyContent) {
+                    editor.edit((edit) => {
+                        edit.replace(textRange, formattedContent);
+                    });
+                }
+            })
+            .catch(this.notifyError);
     }
 }
 

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -1,7 +1,7 @@
 const Linter = require("./Linter");
 const Formatter = require("./Formatter");
 
-exports.activate = function() {
+exports.activate = function () {
     const linter = new Linter();
     const formatter = new Formatter();
 
@@ -12,15 +12,15 @@ exports.activate = function() {
 
         linter.lintDocument(document);
 
-        editor.onDidSave(editor => linter.lintDocument(document));
-        document.onDidChangeSyntax(document => linter.lintDocument(document));
+        editor.onDidSave((editor) => linter.lintDocument(document));
+        document.onDidChangeSyntax((document) => linter.lintDocument(document));
         editor.onWillSave((editor) => {
             const formatOnSave = nova.workspace.config.get("is.flother.Blake.formatOnSave");
-            if (formatOnSave) formatter.format(editor);
+            if (formatOnSave) return formatter.format(editor);
         });
 
-        editor.onDidDestroy(destroyedEditor => {
-            let anotherEditor = nova.workspace.textEditors.find(editor => {
+        editor.onDidDestroy((destroyedEditor) => {
+            let anotherEditor = nova.workspace.textEditors.find((editor) => {
                 return editor.document.path === destroyedEditor.document.path;
             });
             if (!anotherEditor) {

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -1,7 +1,7 @@
 const Linter = require("./Linter");
 const Formatter = require("./Formatter");
 
-exports.activate = function () {
+exports.activate = function() {
     const linter = new Linter();
     const formatter = new Formatter();
 
@@ -12,15 +12,15 @@ exports.activate = function () {
 
         linter.lintDocument(document);
 
-        editor.onDidSave((editor) => linter.lintDocument(document));
-        document.onDidChangeSyntax((document) => linter.lintDocument(document));
+        editor.onDidSave(editor => linter.lintDocument(document));
+        document.onDidChangeSyntax(document => linter.lintDocument(document));
         editor.onWillSave((editor) => {
             const formatOnSave = nova.workspace.config.get("is.flother.Blake.formatOnSave");
             if (formatOnSave) return formatter.format(editor);
         });
 
-        editor.onDidDestroy((destroyedEditor) => {
-            let anotherEditor = nova.workspace.textEditors.find((editor) => {
+        editor.onDidDestroy(destroyedEditor => {
+            let anotherEditor = nova.workspace.textEditors.find(editor => {
                 return editor.document.path === destroyedEditor.document.path;
             });
             if (!anotherEditor) {


### PR DESCRIPTION
There's a bunch here and I'm happy to explain any of it. I also totally understand if this is not a solution you're looking for. Feel free to use this as inspiration for a different solution. I won't be offended at all.

---

When saving a document, Nova would save the file, then Black would
apply the formatting after the save. This left the document as unsaved
_after an explicit save_. To ensure that nova waits for the Black
process to finish, Nova's onWillSave method needs to return a Promise.
It will wait for 5 seconds while that promise resolves, ensuring that
the document will be reformatted first and saved second. This refactor
attempts just that.

The main refactor is around the execute method of BlackProcess and the
format method of Formatter. execute now returns a promise. If the
promise resolves, it passes the formatted text to the formatter, which
calls the edit function on the document to make the change. If the
promise rejects it represents a failure in some way. The formatter
catches this rejection and creates a notification for the user. It's
often (but not always) the case that the error is something the user
would want to know about, like a malformed python document.

This also

* Formatted the edited files through Prettier
* removed `didExit` from BlackProcess
* Removed some unused async declarations from BlackProcess
* Formatter returns the results of BlackProcess.execute
* main returns the result of Formatter.format

Fixes #1 